### PR TITLE
Fixed ".bmp.bmp" bug

### DIFF
--- a/AC_e-Reader_Card_Creator/Print-Frontend.cs
+++ b/AC_e-Reader_Card_Creator/Print-Frontend.cs
@@ -70,6 +70,7 @@ namespace AC_e_Reader_Card_Creator
 
             SaveFileDialog saveRAWFile = new SaveFileDialog
             {
+                Filter = "Bitmap Images (*.bmp)|*.bmp",
                 Title = "Save Dot Code (.bmp)",
                 FileName = "dotcode"
             };
@@ -79,7 +80,7 @@ namespace AC_e_Reader_Card_Creator
                 ProcessStartInfo raw_to_bmp = new ProcessStartInfo
                 {
                     FileName = Common.RAW2BMP,
-                    Arguments = Common.RAW2BMP_ARGS(saveRAWFile.FileName, DPI),
+                    Arguments = Common.RAW2BMP_ARGS(saveRAWFile.FileName.Replace(".bmp", ""), DPI),
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     CreateNoWindow = true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The e-Reader Card Creator is a frontend tool written primarily in C# designed to
 
 This tool currently only supports Windows operating systems.
 
-IMPORTANT: Please keep the main executable in the same root directoy as `/Project Files/`
+IMPORTANT: Please keep the main executable in the same root directory as `/Project Files/`
 
 ## Supported e-Cards & Formats
 As of right now, this tool is designed specifically for a subset of North American Animal Crossing cards:
@@ -30,7 +30,7 @@ If you're interested in printing physical dot codes, you will also need to meet 
 ### Installation
 Head to the [Releases page](https://github.com/Hunter-Raff/e-ReaderCardCreator/releases) to download the ZIP file and extract the latest version of this tool. 
 
-Alternatively, you can download the source files here and build through Visual Studio 2019 or higher. If building from source, you'll need to modify the folder structure to include `/Decompression/` and `/References/` and `/Resources/` inside a root `/Project Files/` folder.
+Alternatively, you can download the source files here and build them through Visual Studio 2019 or higher. If building from source, you'll need to modify the folder structure to include `/Decompression/` and `/References/` and `/Resources/` inside a root `/Project Files/` folder.
 
 ### Usage
 
@@ -78,13 +78,13 @@ If nothing works, you can try to print from a `.raw` file directly through CaitS
 ## Known Bugs
 - Typing in the letter body textbox requires using newlines for the preview to update properly
 - Some rendering issues with the preview letter (*see: Bunnie's official e-Card data*)
-- Saving a dot code as a `.bmp` image currently does not prompt for the `.bmp` file extension. Saving still works, but manually adding the extension will save it with a double extension (`.bmp.bmp`)
+- ~~Saving a dot code as a `.bmp` image currently does not prompt for the `.bmp` file extension. Saving still works, but manually adding the extension will save it with a double extension (`.bmp.bmp`)~~ Fixed by Mike, aka [AkagitsuneYuki](https://github.com/AkagitsuneYuki)
 
 ## To-Do
 - Add GBA letter customization support
 - Add card ID support; card IDs are currently randomly set
 - Convert external e-Reader dev tools to innate code without processing separately
-- Add more error handling
+- Add more error-handling
 - Look into DnM e+ support
 
 ## Contact


### PR DESCRIPTION
Fixed the ".bmp.bmp" bug when saving dotcode bitmaps.

Also updated the readme to reflect this (along with some minor spelling and grammar fixes).